### PR TITLE
Respect pathname in rootUrl when using an absolute URL

### DIFF
--- a/src/AbstractRequest.js
+++ b/src/AbstractRequest.js
@@ -39,12 +39,13 @@ export default class AbstractRequest {
     subrequests = {};
 
     /**
-     * @param {String} pathname
+     * @param {String} resource
      *
      * @return {String}
      */
-    buildEndpoint(pathname) {
-        const {protocol, host} = parseUrl(this.rootUrl);
+    buildEndpoint(resource) {
+        const {protocol, host, path} = parseUrl(this.rootUrl);
+        const pathname = `${path.replace(/^\/|\/$/g, '')}/${resource}`;
         const query = this.query;
 
         const built = buildQuery({protocol, host, pathname, query});

--- a/src/AbstractRequest.js
+++ b/src/AbstractRequest.js
@@ -45,7 +45,7 @@ export default class AbstractRequest {
      */
     buildEndpoint(resource) {
         const {protocol, host, path} = parseUrl(this.rootUrl);
-        const pathname = `${path.replace(/^\/|\/$/g, '')}/${resource}`;
+        const pathname = protocol && host ? `${path.replace(/^\/|\/$/g, '')}/${resource}` : resource;
         const query = this.query;
 
         const built = buildQuery({protocol, host, pathname, query});

--- a/tests/AbstractRequest.test.js
+++ b/tests/AbstractRequest.test.js
@@ -29,6 +29,7 @@ describe('AbstractRequest', () => {
             Authorization: 'Bearer foo',
         },
     }));
+    fetchMock.mock('http://google.com/foo/bar/options', (url, options) => ({url, options}));
 
     beforeEach(() => {
         requests = new AbstractRequest();
@@ -192,6 +193,17 @@ describe('AbstractRequest', () => {
                 .then(response => {
                     assert.equal(response.data.options.method, 'GET');
                     assert.equal(response.data.url, '/api/options');
+                });
+        });
+
+        it('can have absolute rootUrls with extra pathnames', () => {
+            requests.rootUrl = 'http://google.com/foo/bar';
+
+            return requests
+                .make('options')
+                .then(response => {
+                    assert.equal(response.data.options.method, 'GET');
+                    assert.equal(response.data.url, 'http://google.com/foo/bar/options');
                 });
         });
 


### PR DESCRIPTION
### Fixed
- Respect pathname in rootUrl when using an absolute URL

----
#5 