### PR TITLE
Allow html error response

### DIFF
--- a/src/Helpers/index.js
+++ b/src/Helpers/index.js
@@ -1,2 +1,3 @@
 export {default as buildOptions} from './buildOptions';
 export {default as buildQuery} from './buildQuery';
+export {default as jsonParser} from './jsonParser';

--- a/src/Helpers/jsonParser.js
+++ b/src/Helpers/jsonParser.js
@@ -1,0 +1,7 @@
+export default function jsonParser(string) {
+    try {
+        return JSON.parse(string);
+    } catch (error) {
+        return string;
+    }
+}

--- a/src/Middlewares/parseJson.js
+++ b/src/Middlewares/parseJson.js
@@ -1,3 +1,4 @@
+import {jsonParser} from '../Helpers';
 import {NO_CONTENT} from '../HttpStatusCodes';
 
 export default response => {
@@ -19,7 +20,7 @@ export default response => {
             return response;
         }
 
-        response.data = JSON.parse(data);
+        response.data = jsonParser(data);
         if (response.ok) {
             return response;
         }

--- a/tests/Middlewares/parseJson.test.js
+++ b/tests/Middlewares/parseJson.test.js
@@ -13,6 +13,12 @@ describe('parseJson', () => {
             }
         });
     }));
+    fetchMock.mock('http://google.com/html-error', new Promise(resolve => {
+        resolve({
+            status: 422,
+            body: '<p>Error!</p>'
+        });
+    }));
 
     it('can parse a JSON response', () => {
         return fetch('http://google.com/foo').then(parseJson).then(response => {
@@ -37,5 +43,12 @@ describe('parseJson', () => {
             expect(response.message).toEqual('Unprocessable Entity');
             expect(response.data).toEqual({foo: 'bar'});
         });
+    });
+
+    it('can parse html error respnses', () => {
+        return fetch('http://google.com/html-error').then(parseJson).catch(response => {
+            expect(response.message).toEqual('Unprocessable Entity');
+            expect(response.data).toEqual('<p>Error!</p>');
+        })
     });
 });


### PR DESCRIPTION
### Fixed
- Allow the body of an error response to be html